### PR TITLE
using env variable for config directory if it exists

### DIFF
--- a/src/bin/ingestor-gui.py
+++ b/src/bin/ingestor-gui.py
@@ -31,6 +31,8 @@ class Application(QtWidgets.QApplication):
         # getting configuration directory from the args
         if len(argv) > 1:
             self.__configurationDirectory = argv[1]
+        elif 'INGESTOR_CONFIG_DIR' in os.environ:
+            self.__configurationDirectory = os.environ['INGESTOR_CONFIG_DIR']
 
         self.updateConfiguration()
         self.__main.setWindowTitle('Ingestor ({0})'.format(self.__configurationDirectory))


### PR DESCRIPTION
if no config directory is provided, check if the 'INGESTOR_CONFIG_DIR' env variable is defined. This is used by shotgun toolkit to launch the ingestor for plate/texture/render publishes.

- Using environment variable to define config directory if none is provided (#22)