### PR TITLE
Image sequence detection issue

### DIFF
--- a/src/lib/ingestor/Crawler/Fs/Image/Image.py
+++ b/src/lib/ingestor/Crawler/Fs/Image/Image.py
@@ -88,6 +88,7 @@ class Image(File):
         """
         nameParts = self.pathHolder().baseName().split(".")
         parts = nameParts[0].split("_")
+        isImageSeq = False
         if len(parts) > 1:
             isImageSeq = (parts[-1].isdigit() and len(parts[-1]) >= 4)
 


### PR DESCRIPTION
It was missing a default value for "isImageSeq" which would result in an error when the file is not an image sequence.

- Image crawler: fixed bug during the detection of image sequences padded by "_"