### PR TITLE
Avoiding to create directories before the execution of the task

### DIFF
--- a/src/lib/ingestor/Task/Version/CreateVersion.py
+++ b/src/lib/ingestor/Task/Version/CreateVersion.py
@@ -179,7 +179,7 @@ class CreateVersion(Task):
         Run the task.
 
         We need to wrap this call to make sure the versionPath is created before
-        any of the sub-classess try to write to it through _perform.
+        any of the sub-classes try to write to it through _perform.
         """
         os.makedirs(self.versionPath())
 


### PR DESCRIPTION
This pull request fixes a bug related with the CreateVersion task about creating the directory for the version before the execution of the task. By having this issue the task would fail during the execution by trying to create that directory using the proper user, permissions etc...

- CreateVersion Task: avoiding to create directories before the execution of the task