### PR TITLE
Deleted OCIO env variable due to a crashing with nuke configuration

### DIFF
--- a/src/lib/ingestor/Task/ImageSequence/NukeScript.py
+++ b/src/lib/ingestor/Task/ImageSequence/NukeScript.py
@@ -97,7 +97,7 @@ class NukeScript(Task):
             # calling nuke
             customEvn = dict(os.environ)
 
-            # delete variable due to a crashing with nuke configuration
+            # delete variable due to a crash with nuke configuration
             if 'OCIO' in customEvn:
                 del customEvn['OCIO']
 


### PR DESCRIPTION
Deleted OCIO env variable due to a crashing with nuke configuration