### PR TITLE
nukeTemplate proper output

### DIFF
--- a/src/lib/ingestor/Task/ImageSequence/NukeTemplate.py
+++ b/src/lib/ingestor/Task/ImageSequence/NukeTemplate.py
@@ -1,4 +1,7 @@
 import os
+import json
+import tempfile
+from ...Crawler.Fs import Path
 from ..Task import Task
 from .NukeScript import NukeScript
 
@@ -27,6 +30,29 @@ class NukeTemplate(NukeScript):
                 "loadTemplate.py"
             )
         )
+
+        self.setOption(
+            '_renderOutputData',
+            tempfile.NamedTemporaryFile(suffix='.json').name
+        )
+
+    def _perform(self):
+        """
+        Execute the task.
+        """
+        super(NukeTemplate, self)._perform()
+
+        # we want to return a list of crawlers about the files that were
+        # created during the execution (render) of the nuke file
+        # which can be multiple write nodes.
+        fileList = []
+        with open(self.option('_renderOutputData')) as jsonFile:
+            fileList = json.load(jsonFile)
+
+        # no longer need the render output data file
+        os.remove(self.option('_renderOutputData'))
+
+        return list(map(Path.createFromPath, fileList))
 
 
 # registering task

--- a/src/lib/ingestor/Task/ImageSequence/aux/loadTemplate.py
+++ b/src/lib/ingestor/Task/ImageSequence/aux/loadTemplate.py
@@ -1,4 +1,6 @@
 import nuke
+import json
+import StringIO
 
 # reading options from the task.
 # sourceSequence, targetSequence, startFrame and endFrame are added automatically as options by
@@ -15,6 +17,7 @@ nuke.root()['first_frame'].setValue(startFrame)
 nuke.root()['last_frame'].setValue(endFrame)
 
 # executing the write node
+createdFiles = []
 for writeNode in nuke.allNodes('Write'):
 
     # skipping disabled write nodes
@@ -22,3 +25,20 @@ for writeNode in nuke.allNodes('Write'):
         continue
 
     nuke.execute(writeNode, int(writeNode['first'].value()), int(writeNode['last'].value()))
+
+    # multiple files (image sequence)
+    currentFile = writeNode['file'].getValue()
+    if "%0" in currentFile:
+        for frame in range(writeNode['first'].value(), int(writeNode['last'].value())):
+            bufferString = StringIO.StringIO()
+            bufferString.write(currentFile % frame)
+
+            createdFiles.append(bufferString.getvalue())
+
+    # single file
+    else:
+        createdFiles.append(currentFile)
+
+# writting a json file with a list about all files created by the render
+with open(options['_renderOutputData'], 'w') as output:
+    json.dump(createdFiles, output)


### PR DESCRIPTION
This pull request makes sure that files created during the execution of the nuke file by the write nodes are properly passed as output of the nuke template task. Therefore, creating a crawler proper for each of the files that were generated by nuke.

- NukeTemplate Task: making sure to return all files created by the write nodes as output the task